### PR TITLE
Remove logs after hotfix

### DIFF
--- a/src/Enroll/Table/index.tsx
+++ b/src/Enroll/Table/index.tsx
@@ -186,9 +186,6 @@ export function EnrollTable({
       (item_class) => item_class.name === item.class
     );
 
-    console.log(item);
-    console.log(admin);
-
     item.text_link = `?text=Olá%20${
       item?.user?.name ? item?.user?.name.split(" ")[0] : ""
     },\%0AAqui%20é%20${


### PR DESCRIPTION
- Some enrolls didn't have user name and phone
- A hotfix validated this cases to avoid trying to show those fields when missing
- Logs were added to debug with production data
- Those are not required anymore
- This PR removes those logs

---

- :warning: `@TODO` - understand why there are missing fields in production database. 